### PR TITLE
Ability to pass arguments to omxplayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ application, you can use it to start up a new instance of omxplayer, providing a
 path to the file you would like to play:
 
 ```go
-player, err := omxplayer.New("/path/to/video.mp4")
+player, err := omxplayer.New("/path/to/video.mp4", "--no-osd")
 ```
 
 This will start a new omxplayer process that will play the specified video file.
@@ -121,7 +121,7 @@ Here's an example to bring it all together:
 
 ```go
 omxplayer.SetUser("root", "/root")
-player, err := omxplayer.New("/root/testvideo.mp4")
+player, err := omxplayer.New("/root/testvideo.mp4", "--no-osd")
 
 player.WaitForReady()
 err = player.PlayPause()

--- a/omxplayer.go
+++ b/omxplayer.go
@@ -161,4 +161,3 @@ func execOmxplayer(url string, arg ...string) (cmd *exec.Cmd, err error) {
 	err = cmd.Start()
 	return
 }
-

--- a/omxplayer.go
+++ b/omxplayer.go
@@ -47,10 +47,10 @@ func SetUser(u, h string) {
 
 // New returns a new Player instance that can be used to control an OMXPlayer
 // instance that is playing the video located at the specified URL.
-func New(url string) (player *Player, err error) {
+func New(url string, arg ...string) (player *Player, err error) {
 	removeDbusFiles()
 
-	cmd, err := execOmxplayer(url)
+	cmd, err := execOmxplayer(url, arg...)
 	if err != nil {
 		return
 	}
@@ -152,11 +152,13 @@ func setupDbusEnvironment() (err error) {
 
 // execOmxplayer starts a new OMXPlayer process and tells it to pause the video
 // by passing a "p" on standard input.
-func execOmxplayer(url string) (cmd *exec.Cmd, err error) {
+func execOmxplayer(url string, arg ...string) (cmd *exec.Cmd, err error) {
 	log.Debug("omxplayer: starting omxplayer process")
 
-	cmd = exec.Command(exeOxmPlayer, "--no-osd", url)
+	arg = append(arg, url)
+	cmd = exec.Command(exeOxmPlayer, arg...)
 	cmd.Stdin = strings.NewReader(keyPause)
 	err = cmd.Start()
 	return
 }
+


### PR DESCRIPTION
I faced with necessity to pass `--win` and `-b` flags to omxplayer over cli. This PR is adding this feature.

Please note that `New()` function now has second param so it may break something somewhere :)