### PR TITLE
Fixed case-insensitive import collision.

### DIFF
--- a/omxplayer.go
+++ b/omxplayer.go
@@ -7,8 +7,8 @@ import (
 	"os/exec"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	dbus "github.com/guelfey/go.dbus"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/omxplayer_helpers.go
+++ b/omxplayer_helpers.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // removeFile removes the specified file. Errors are ignored.

--- a/player.go
+++ b/player.go
@@ -6,8 +6,8 @@ import (
 	"syscall"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	dbus "github.com/guelfey/go.dbus"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/player_helpers.go
+++ b/player_helpers.go
@@ -1,8 +1,8 @@
 package omxplayer
 
 import (
-	log "github.com/Sirupsen/logrus"
 	dbus "github.com/guelfey/go.dbus"
+	log "github.com/sirupsen/logrus"
 )
 
 // dbusCall calls a D-Bus method that has no return value.


### PR DESCRIPTION
* Ubuntu 18.04 LTS
* go version go1.10.1 linux/amd64

Can not be resolved if mixed upper and lower case references.
It was necessary to change to reference of lowercase letters.
https://github.com/sirupsen/logrus/issues/543

```
case-insensitive import collision: "github.com/sirupsen/logrus" and "github.com/Sirupsen/logrus"
```

Please review :)