### PR TITLE
fix SetPosition method

### DIFF
--- a/player.go
+++ b/player.go
@@ -251,7 +251,7 @@ func (p *Player) SetPosition(path string, position int64) (int64, error) {
 		"paramPath":     path,
 		"paramPosition": position,
 	}).Debug("omxplayer: dbus call")
-	call := p.bus.Call(cmdSetPosition, 0, path, position)
+	call := p.bus.Call(cmdSetPosition, 0, dbus.ObjectPath(path), position)
 	if call.Err != nil {
 		return 0, call.Err
 	}


### PR DESCRIPTION
the `path` parameter should be object_path of dbus or the player ignores the command that will throw a painc since the `call.Body` is empty but `call.Body[0]` used
see https://github.com/popcornmix/omxplayer/issues/684